### PR TITLE
fix(server/mcp): apply Smithery session config, initialize DB & logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ ENV ZETTELKASTEN_LOG_LEVEL=DEBUG
 # Create necessary directories
 RUN mkdir -p /data/notes /data/db
 
-ENV FASTMCP_TRANSPORT=stdio
-ENV FASTMCP_HOST 0.0.0.0
+# FastMCP HTTP transport configuration (Smithery will set these)
+ENV FASTMCP_HOST=0.0.0.0
 ENV FASTMCP_PORT=8000
 EXPOSE 8000
 

--- a/src/zettelkasten_mcp/models/db_models.py
+++ b/src/zettelkasten_mcp/models/db_models.py
@@ -1,7 +1,9 @@
 """SQLAlchemy database models for the Zettelkasten MCP server."""
-import datetime
-from typing import List, Optional
+from __future__ import annotations
 
+import datetime
+
+import sqlalchemy.engine
 from sqlalchemy import (Column, DateTime, ForeignKey, Integer, String, Table,
                        Text, UniqueConstraint, create_engine)
 from sqlalchemy.ext.declarative import declarative_base
@@ -98,14 +100,14 @@ class DBLink(Base):
             f"target='{self.target_id}', type='{self.link_type}')>"
         )
 
-def init_db() -> None:
+def init_db() -> sqlalchemy.engine.Engine:
     """Initialize the database."""
     # Create engine based on configuration
     engine = create_engine(config.get_db_url())
     Base.metadata.create_all(engine)
     return engine
 
-def get_session_factory(engine=None):
+def get_session_factory(engine: sqlalchemy.engine.Engine | None = None) -> Session:
     """Get a session factory for the database."""
     if engine is None:
         engine = create_engine(config.get_db_url())


### PR DESCRIPTION
## Affected Areas
- 🖥️ Server/MCP
- 🗄️ Database Models
- 🐳 Dockerfile

## Key Changes
- 🎯 Accept session_config in create_server
- ⚙️ Apply session_config to config values
- 🪵 Initialize logging via setup_logging
- 📁 Ensure notes directory exists
- 🧩 Initialize DB schema at startup (init_db)
- 🔒 Log DB URL with password hidden
- 🧰 Import and use init_db/setup_logging
- 🔎 Add precise type hints to db_models
- 🧹 Tidy unused imports and formatting
- 🐳 Remove FASTMCP_TRANSPORT env var