### PR TITLE
Pin Docker base to bookworm for MS ODBC compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary
- pin Docker base image from `python:3.11-slim` to `python:3.11-slim-bookworm`

## Why
`python:3.11-slim` currently resolves to Debian trixie in CI. During SQL Server ODBC setup, apt in trixie rejects Microsoft's repo signing chain under newer SHA1 policy checks, causing Docker publish failures.

Pinning to `bookworm` restores compatibility with Microsoft\'s Debian 12 package signing for `msodbcsql18`.
