### PR TITLE
Add native pipx/uvx support docs and CI smoke tests

### DIFF
--- a/.github/workflows/pipx-uvx-smoke.yaml
+++ b/.github/workflows/pipx-uvx-smoke.yaml
@@ -1,0 +1,39 @@
+name: pipx/uvx smoke tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  native-install-smoke:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11"]
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pipx and uv
+        run: |
+          set -eux
+          python -m pip install --upgrade pip
+          python -m pip install pipx uv
+
+      - name: pipx run smoke test
+        run: |
+          set -eux
+          python -m pipx run --spec . zettelkasten-mcp --help
+
+      - name: uvx run smoke test
+        run: |
+          set -eux
+          uvx --from . zettelkasten-mcp --help

--- a/README.md
+++ b/README.md
@@ -132,6 +132,32 @@ npx -y @smithery/cli install zettelkasten-mcp --client claude
 uvx --from=git+https://github.com/entanglr/zettelkasten-mcp zettelkasten-mcp --notes-dir ./data/notes --database ./data/db/zettelkasten.db
 ```
 
+### Via pipx (native macOS/Linux/Windows)
+
+Install from GitHub:
+
+```bash
+pipx install "git+https://github.com/entanglr/zettelkasten-mcp.git"
+```
+
+If/when published on PyPI, install from PyPI instead:
+
+```bash
+pipx install zettelkasten-mcp
+```
+
+Run the server:
+
+```bash
+zettelkasten-mcp --notes-dir ./data/notes --database ./data/db/zettelkasten.db
+```
+
+### Native Apple Silicon (non-Docker)
+
+On Apple Silicon Macs, prefer `pipx`/`uvx` for native `darwin/arm64`
+execution. Docker images are Linux-only (`linux/amd64`, `linux/arm64`) and do
+not provide a native `darwin` container target.
+
 ### Docker image architecture support
 
 The `latest` image tag is published as a multi-arch image manifest with:


### PR DESCRIPTION
## Summary
- add README guidance for native (non-Docker) macOS support via `pipx`/`uvx`
- add explicit install/run examples for `pipx`
- add a new CI workflow to smoke-test `pipx` and `uvx` execution on both `ubuntu-latest` and `macos-latest`

## Validation
- local smoke commands passed:
  - `python -m pipx run --spec . zettelkasten-mcp --help`
  - `uvx --from . zettelkasten-mcp --help`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation guidance for pipx, supporting both GitHub and PyPI installation methods
  * Included server execution commands for pipx-based deployments
  * Added guidance for native Apple Silicon execution using pipx/uvx
  * Expanded Docker support documentation covering multiple architectures with detailed backend compatibility matrix
  * Documented backend availability across architectures, noting arm64 SQL Server ODBC limitations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->